### PR TITLE
add a SetDebugCallback function

### DIFF
--- a/goHamlib_test.go
+++ b/goHamlib_test.go
@@ -322,3 +322,16 @@ func TestListModels(t *testing.T) {
 		t.Errorf("did not find the hamlib standard dummy driver")
 	}
 }
+
+func TestDebugCallback(t *testing.T) {
+	called := 0
+	goHamlib.SetDebugCallback(func(lvl goHamlib.DebugLevel, msg string) {
+		called++
+	})
+	goHamlib.SetDebugLevel(goHamlib.DebugTrace)
+	goHamlib.ListModels()
+	goHamlib.SetDebugLevel(goHamlib.DebugWarn)
+	if called == 0 {
+		t.Errorf("expected a debug message, got none")
+	}
+}

--- a/rig.c
+++ b/rig.c
@@ -936,3 +936,15 @@ int cleanup_rig(RIG *myrig)
 	return res;
 }
 
+extern void go_debug_print(enum rig_debug_level_e debug_level, char *msg);
+int internal_debug_cb(enum rig_debug_level_e debug_level, rig_ptr_t user_data, const char *fmt, va_list ap)
+{
+	char buf[1024];
+	vsprintf (buf, fmt, ap);
+	go_debug_print(debug_level, buf);
+	return RIG_OK;
+}
+
+void set_debug_callback() {
+	rig_set_debug_callback(internal_debug_cb, NULL);
+}


### PR DESCRIPTION
The primary purpose is catching hamlib error
logging so we can redirect it instead of letting it
corrupt a terminal display.