### PR TITLE
update for hamlib4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 *.out
 settings.json
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+**This (hopefully temporary) fork supports Hamlib v4.**
+
 # Hamlib binding for Golang
-[![Go Report Card](https://goreportcard.com/badge/github.com/dh1tw/goHamlib)](https://goreportcard.com/report/github.com/dh1tw/goHamlib)
-[![Build Status](https://travis-ci.org/dh1tw/goHamlib.svg?branch=master)](https://travis-ci.org/dh1tw/goHamlib)
-[![Coverage Status](https://coveralls.io/repos/github/dh1tw/goHamlib/badge.svg?branch=master)](https://coveralls.io/github/dh1tw/goHamlib?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xylo04/goHamlib)](https://goreportcard.com/report/github.com/xylo04/goHamlib)
+[![Build Status](https://travis-ci.org/xylo04/goHamlib.svg?branch=master)](https://travis-ci.org/xylo04/goHamlib)
+[![Coverage Status](https://coveralls.io/repos/github/xylo04/goHamlib/badge.svg?branch=master)](https://coveralls.io/github/xylo04/goHamlib?branch=master)
 
 This is a [golang](https://golang.org) binding for
 [Hamlib](http://hamlib.org). The binding has been hand written in order
@@ -9,7 +11,7 @@ to provide a golang idiomatic API but staying also close as possible to
 [hamlib's C API](http://hamlib.sourceforge.net/manuals/3.0.1/index.html).
 Except of Hamlib (C), goHamlib has no other external dependencies.
 
-goHamlib is compatible with both, Hamlib 1.2.x and 3.x.
+goHamlib is compatible with both, Hamlib 4.x.
 
 You might also want to checkout [gorigctl](https://github.com/dh1tw/gorigctl)
 which is a drop-in replacement for hamlib's rigctl, although it comes with a
@@ -69,7 +71,7 @@ $ brew install hamlib
 ### Compilation
 
 ```bash
-$ go get github.com/dh1tw/goHamlib
+$ go get github.com/xylo04/goHamlib
 ```
 
 ## Tests
@@ -78,15 +80,15 @@ Most of goHamlib's API is unit tested. In order to execute the unit tests,
 run: 
 
 ```bash
-$ cd $GOPATH/src/github.com/dh1tw/goHamlib
+$ cd $GOPATH/src/github.com/xylo04/goHamlib
 $ go test
 ```
 
 ## Documentation
 
-goHamlib's API is documented at [go.dev](https://pkg.go.dev/github.com/dh1tw/goHamlib)
+goHamlib's API is documented at [go.dev](https://pkg.go.dev/github.com/xylo04/goHamlib)
 
 ## Example
 
-Checkout the [dummyrig_test.go](https://github.com/dh1tw/goHamlib/blob/master/dummyrig_test.go) in this
+Checkout the [dummyrig_test.go](https://github.com/xylo04/goHamlib/blob/master/dummyrig_test.go) in this
 repository to see how to use goHamlib.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ brew install hamlib
 ### Compilation
 
 ```bash
-$ go get github.com/xylo04/goHamlib
+$ go get github.com/dl1igc/goHamlib
 ```
 
 ## Tests
@@ -80,7 +80,7 @@ Most of goHamlib's API is unit tested. In order to execute the unit tests,
 run: 
 
 ```bash
-$ cd $GOPATH/src/github.com/xylo04/goHamlib
+$ cd $GOPATH/src/github.com/dl1igc/goHamlib
 $ go test
 ```
 

--- a/dummyrig_test.go
+++ b/dummyrig_test.go
@@ -1,7 +1,7 @@
 package goHamlib_test
 
 import (
-	"github.com/dh1tw/goHamlib"
+	"github.com/xylo04/goHamlib"
 	"reflect"
 	"testing"
 )

--- a/dummyrig_test.go
+++ b/dummyrig_test.go
@@ -1,9 +1,10 @@
 package goHamlib_test
 
 import (
-	"github.com/xylo04/goHamlib"
 	"reflect"
 	"testing"
+
+	"github.com/dl1igc/goHamlib"
 )
 
 func getDummyRig() (*goHamlib.Rig, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/xylo04/goHamlib
+module github.com/dl1igc/goHamlib
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dh1tw/goHamlib
+module github.com/xylo04/goHamlib
 
 go 1.14

--- a/goHamlib_test.go
+++ b/goHamlib_test.go
@@ -3,7 +3,7 @@ package goHamlib_test
 import (
 	"testing"
 
-	"github.com/xylo04/goHamlib"
+	"github.com/dl1igc/goHamlib"
 )
 
 // Test consistency of Vfo Value and Name maps

--- a/goHamlib_test.go
+++ b/goHamlib_test.go
@@ -3,7 +3,7 @@ package goHamlib_test
 import (
 	"testing"
 
-	"github.com/dh1tw/goHamlib"
+	"github.com/xylo04/goHamlib"
 )
 
 // Test consistency of Vfo Value and Name maps

--- a/rig.c
+++ b/rig.c
@@ -883,7 +883,7 @@ int get_supported_modes(RIG *myrig, int *modes)
 int get_filter_count(RIG *myrig, int *filter_count)
 {
 	int i;
-	for (i=0; i<FLTLSTSIZ && !RIG_IS_FLT_END(myrig->caps->filters[i]); i++)
+	for (i=0; i<HAMLIB_FLTLSTSIZ && !RIG_IS_FLT_END(myrig->caps->filters[i]); i++)
 	{
 		*filter_count += 1;
 	}

--- a/rig.c
+++ b/rig.c
@@ -403,9 +403,9 @@ int has_set_ant(RIG *myrig)
 	return RIG_ENIMPL;
 }
 
-int set_ant(RIG *myrig, int vfo, int ant)
+int set_ant(RIG *myrig, vfo_t vfo, ant_t ant, value_t option)
 {
-	int res = rig_set_ant(myrig, vfo, ant);
+	int res = rig_set_ant(myrig, vfo, ant, option);
 	return res;
 }
 
@@ -418,9 +418,9 @@ int has_get_ant(RIG *myrig)
 	return RIG_ENIMPL;
 }
 
-int get_ant(RIG *myrig, int vfo, int *ant)
+int get_ant(RIG *myrig, vfo_t vfo, ant_t ant, value_t *option, ant_t *ant_curr, ant_t *ant_tx, ant_t *ant_rx)
 {
-	int res = rig_get_ant(myrig, vfo, ant);
+	int res = rig_get_ant(myrig, vfo, ant, option, ant_curr,ant_tx, ant_rx);
 	return res;
 }
 
@@ -580,7 +580,7 @@ int get_level(RIG *myrig, int vfo, unsigned long level, float *value)
 		case RIG_LEVEL_CWPITCH:
 		case RIG_LEVEL_KEYSPD:
 		case RIG_LEVEL_NOTCHF:
-		case RIG_LEVEL_VOX:
+		case RIG_LEVEL_VOXDELAY:
 		case RIG_LEVEL_BKINDL:
 		case RIG_LEVEL_METER:
 		case RIG_LEVEL_STRENGTH:
@@ -649,7 +649,7 @@ int get_level_gran(RIG *myrig, unsigned long level, float *step, float *min, flo
 		case RIG_LEVEL_CWPITCH:
 		case RIG_LEVEL_KEYSPD:
 		case RIG_LEVEL_NOTCHF:
-		case RIG_LEVEL_VOX:
+		case RIG_LEVEL_VOXDELAY:
 		case RIG_LEVEL_BKINDL:
 		case RIG_LEVEL_METER:
 		case RIG_LEVEL_STRENGTH:
@@ -699,7 +699,7 @@ int set_level(RIG *myrig, int vfo, unsigned long level, float value)
 		case RIG_LEVEL_CWPITCH:
 		case RIG_LEVEL_KEYSPD:
 		case RIG_LEVEL_NOTCHF:
-		case RIG_LEVEL_VOX:
+		case RIG_LEVEL_VOXDELAY:
 		case RIG_LEVEL_BKINDL:
 		case RIG_LEVEL_METER:
 		case RIG_LEVEL_SLOPE_LOW:


### PR DESCRIPTION
With this changes this library is able to compile against libham4. Basic function works with FTDX3000.